### PR TITLE
Measure report endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,12 @@ Web service wrapper for [fqm-execution](https://github.com/projecttacoma/fqm-exe
 
 | Endpoint | Input | Output |
 | -------- | ----- | ------ |
+
+| `POST /calculate` | [RequestBody](https://github.com/projecttacoma/fqm-execution-service/blob/master/src/types/server-types.ts#L3) | [ExecutionResult[]](https://github.com/projecttacoma/fqm-execution/blob/ae4cb08be1796f30a0372d1f06a3167b20c6f25f/src/types/Calculator.ts#L47) |
 | `POST /calculateRaw` | [RequestBody](https://github.com/projecttacoma/fqm-execution-service/blob/master/src/types/server-types.ts#L3) | [cql.Results](https://github.com/projecttacoma/fqm-execution/blob/master/src/types/CQLTypes.ts#L14) |
+| `POST /calculateMeasureReports` | [RequestBody](https://github.com/projecttacoma/fqm-execution-service/blob/master/src/types/server-types.ts#L3) | [R4.IMeasureReport[]](https://www.hl7.org/fhir/measurereport.html) |
 | `POST /Measure/$care-gaps` | [RequestBody](https://github.com/projecttacoma/fqm-execution-service/blob/master/src/types/server-types.ts#L3) | [R4.IBundle](https://www.hl7.org/fhir/bundle.html) |
+<!-- Note: linked line numbers may be inaccurate as code is updated -->
 
 ## Usage
 

--- a/src/app.ts
+++ b/src/app.ts
@@ -33,13 +33,12 @@ app.post('/calculateMeasureReports', (req, res) => {
 
   const { measure, patients, options } = body;
   try {
-    // default calculations to true
-    let opt = options ?? {};
-    opt.calculateHTML = options?.calculateHTML ?? true;
-    opt.calculateSDEs = options?.calculateSDEs ?? true;
-
-    const result = Calculator.calculateMeasureReports(measure, patients, opt);
-    return res.json(result);
+    const measureReportResult = Calculator.calculateMeasureReports(
+      measure,
+      patients,
+      options || {} // options are optional, so this defaults to an empty Object
+    );
+    return res.json(measureReportResult.results);
   } catch (error) {
     return res.status(500).send(error);
   }
@@ -59,6 +58,24 @@ app.post(/^\/Measure\/(\$|%24)care-gaps/, (req, res) => {
       options || {} // options are optional, so this defaults to an empty Object
     );
     return res.json(careGapResult.results);
+  } catch (error) {
+    return res.status(500).send(error);
+  }
+});
+
+app.post('/calculate', (req, res) => {
+  const body = req.body as RequestBody;
+
+  logger.info(`[${req.ip}] POST /calculate`);
+
+  const { measure, patients, options } = body;
+  try {
+    const calculateResult = Calculator.calculate(
+      measure,
+      patients,
+      options || {} // options are optional, so this defaults to an empty Object
+    );
+    return res.json(calculateResult.results);
   } catch (error) {
     return res.status(500).send(error);
   }

--- a/src/app.ts
+++ b/src/app.ts
@@ -26,6 +26,25 @@ app.post('/calculateRaw', (req, res) => {
   }
 });
 
+app.post('/calculateMeasureReports', (req, res) => {
+  const body = req.body as RequestBody;
+
+  logger.info(`[${req.ip}] POST /calculateMeasureReports`);
+
+  const { measure, patients, options } = body;
+  try {
+    // default calculations to true
+    let opt = options ?? {};
+    opt.calculateHTML = options?.calculateHTML ?? true;
+    opt.calculateSDEs = options?.calculateSDEs ?? true;
+
+    const result = Calculator.calculateMeasureReports(measure, patients, opt);
+    return res.json(result);
+  } catch (error) {
+    return res.status(500).send(error);
+  }
+});
+
 // matches '/Measure/$care-gaps' or encoded '/Measure/%24care-gaps'
 app.post(/^\/Measure\/(\$|%24)care-gaps/, (req, res) => {
   const body = req.body as RequestBody;

--- a/test/app.test.ts
+++ b/test/app.test.ts
@@ -46,3 +46,47 @@ test('gaps in care calculate', async () => {
 
   expect(response.body).toEqual(mockCareGapsResult.results);
 });
+
+const mockMeasureReportResult: { results: R4.IMeasureReport[]; debugOutput?: CalculatorTypes.DebugOutput } = {
+  results: [
+    {
+      resourceType: 'MeasureReport',
+      period: {},
+      measure: ''
+    }
+  ],
+  debugOutput: {}
+};
+
+const measureReportSpy = jest.spyOn(Calculator, 'calculateMeasureReports');
+when(measureReportSpy).calledWith(mockMeasureBundle, mockPatientBundles, {}).mockReturnValue(mockMeasureReportResult);
+
+test('measure reports calculate', async () => {
+  const response = await request(app)
+    .post('/calculateMeasureReports')
+    .send({ measure: mockMeasureBundle, patients: mockPatientBundles })
+    .expect(200);
+
+  expect(response.body).toEqual(mockMeasureReportResult.results);
+});
+
+const mockResult: { results: CalculatorTypes.ExecutionResult[]; debugOutput?: CalculatorTypes.DebugOutput } = {
+  results: [
+    {
+      patientId: ''
+    }
+  ],
+  debugOutput: {}
+};
+
+const calculateSpy = jest.spyOn(Calculator, 'calculate');
+when(calculateSpy).calledWith(mockMeasureBundle, mockPatientBundles, {}).mockReturnValue(mockResult);
+
+test('simple calculate', async () => {
+  const response = await request(app)
+    .post('/calculate')
+    .send({ measure: mockMeasureBundle, patients: mockPatientBundles })
+    .expect(200);
+
+  expect(response.body).toEqual(mockResult.results);
+});


### PR DESCRIPTION
# Summary
## New behavior
fqm execution service supports post to /calculate and /calculateMeasureReports endpoints where measure and patients are posted (w/ options) and ExecutionResult array or Measure Report array are returned (respectively)

## Code changes
Added express endpoints to app.ts and added mocked calls to app.test.ts.

## Testing guidance
Currently, there is a mocked test, so you can run `npm test`
You can also run the server with `npm start` and send in a post request to endpoint localhost:3000/calculate or localhost:3000/calculateMeasureReports
Headers:
<img width="463" alt="Screen Shot 2020-12-23 at 11 57 35 AM" src="https://user-images.githubusercontent.com/2643955/103020269-16db4d00-4516-11eb-82c5-b1ec6598e670.png">
Body:
json object containing patients array and measure object (tested with EXM130 from https://github.com/DBCG/connectathon)
