### PR TITLE
Add Dockerfile for service

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,1 @@
+node_modules

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+from node:12
+
+# Create app directory
+WORKDIR /usr/src/app
+
+# Copy package files to get dependencies
+COPY package*.json ./
+
+# Install dependencies
+RUN npm install
+
+# Copy all app files
+COPY . .
+
+# Start app
+EXPOSE 3000
+CMD [ "npm", "start" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-from node:12
+FROM node:12
 
 # Create app directory
 WORKDIR /usr/src/app

--- a/README.md
+++ b/README.md
@@ -15,4 +15,12 @@ Web service wrapper for [fqm-execution](https://github.com/projecttacoma/fqm-exe
 
 ## Usage
 
+### Docker
+
+``` bash
+docker run -p 3000:3000 tacoma/fqm-execution-service:latest # Run server on port 3000
+```
+
+### Local
+
 Run the service with `npm start`. By default, it will run on port 3000. To change the port, do `PORT=XXXX npm start`


### PR DESCRIPTION
FHIR Sprint 2 point task 100% speedrun WR (awaiting verification)

o test:

* `docker build -t tacoma/fqm-execution-service .`
* `docker run -p 3000:3000 tacoma/fqm-execution-service`

Service should start. Ensure you can still hit `localhost:3000` calculate endpoints for calcualtion


When this is merged, I will push up a `tacoma/fqm-execution-service:0.0.1` image (semver matches the package.json) to dockerhub