### PR TITLE
Added docker_hub_build for gh actions

### DIFF
--- a/.github/workflows/docker_hub_build.yml
+++ b/.github/workflows/docker_hub_build.yml
@@ -1,0 +1,50 @@
+name: ci
+
+on:
+  push:
+    branches:
+      - 'master'
+      - 'test-branch'
+    tags:
+      - 'v*.*.*'
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    steps:
+      -
+        name: Checkout
+        uses: actions/checkout@v2
+      -
+        name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v3
+        with:
+          # list of Docker images to use as base name for tags
+          images: |
+            tacoma/fqm-execution-service
+          # generate Docker tags based on the following events/attributes
+          tags: |
+            type=ref,event=branch,pattern=latest
+            type=semver,pattern=release-latest
+            type=semver,pattern={{raw}}
+            type=semver,pattern=v{{major}}-latest
+            type=semver,pattern=v{{major}}.{{minor}}-latest
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      -
+        name: Login to DockerHub
+        uses: docker/login-action@v1 
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      -
+        name: Build and push
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+

--- a/.github/workflows/docker_hub_build.yml
+++ b/.github/workflows/docker_hub_build.yml
@@ -23,6 +23,8 @@ jobs:
           # list of Docker images to use as base name for tags
           images: |
             tacoma/fqm-execution-service
+          flavor: |
+            latest=${{ github.ref == 'refs/heads/master' }}
           # generate Docker tags based on the following events/attributes
           tags: |
             type=ref,event=branch,pattern=latest

--- a/.github/workflows/docker_hub_build.yml
+++ b/.github/workflows/docker_hub_build.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - 'master'
-      - 'test-branch'
     tags:
       - 'v*.*.*'
 
@@ -12,11 +11,9 @@ jobs:
   docker:
     runs-on: ubuntu-latest
     steps:
-      -
-        name: Checkout
+      - name: Checkout
         uses: actions/checkout@v2
-      -
-        name: Docker meta
+      - name: Docker meta
         id: meta
         uses: docker/metadata-action@v3
         with:
@@ -30,21 +27,17 @@ jobs:
             type=semver,pattern={{raw}}
             type=semver,pattern=v{{major}}-latest
             type=semver,pattern=v{{major}}.{{minor}}-latest
-      -
-        name: Set up Docker Buildx
+      - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
-      -
-        name: Login to DockerHub
-        uses: docker/login-action@v1 
+      - name: Login to DockerHub
+        uses: docker/login-action@v1
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
-      -
-        name: Build and push
+      - name: Build and push
         uses: docker/build-push-action@v2
         with:
           context: .
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-


### PR DESCRIPTION
# Summary
The `fqm-execution-service` repository now uses GitHub Actions to create Docker images and populate Docker Hub with them. GitHub Actions is used instead of Docker Autobuilds.

## New Behavior
As mentioned above, the Docker Autobuilds are no longer free because a lot of people were taking advantage of the service for crypto mining. Therefore, we are switching to GitHub Actions, which helps to automate tasks within the software development life cycle. This creates a new workflow that builds and pushes Docker images with Buildx.

## Code Changes
The file `docker_hub_build.yml` was created based on guidance from this README: https://github.com/docker/build-push-action. It contains a job with multiple steps to checkout the repository, generate Docker tags, set up Docker Buildx, login to DockerHub, and build and push. This file is located within `.github/workflows`.

## Testing Guidance
Check in DockerHub that the appropriate updates are made.

I also created a branch called `test-branch` to capture whether the GitHub Actions will work. This branch is currently listed under `branches` in `docker_hub_build.yml`. `test-branch` contains a small change (just a console.log statement) that does not change overall functionality but causes a rebuild so that we can check that it works.